### PR TITLE
nrfxlib: cmake: Adjust nrfxlib_calculate_lib_path to allow SoC mode

### DIFF
--- a/common.cmake
+++ b/common.cmake
@@ -17,8 +17,17 @@ set(__NRFXLIB_COMMON_CMAKE__ TRUE)
 # -wchar_t size
 #
 function(nrfxlib_calculate_lib_path lib_path)
-  # Add Arch type
-  assert(GCC_M_CPU "GCC_M_CPU must be set to find correct lib.")
+  cmake_parse_arguments(CALC_LIB_PATH "SOC_MODE" "" "" ${ARGN})
+
+  if(${CALC_LIB_PATH_SOC_MODE})
+    # CMake regex does not support {4}
+    string(REGEX REPLACE "_[a-zA-Z][a-zA-Z][a-zA-Z][a-zA-Z]$" "" arch_soc_dir ${CONFIG_SOC})
+  else()
+    # Add Arch type
+    assert(GCC_M_CPU "GCC_M_CPU must be set to find correct lib.")
+    set(arch_soc_dir ${GCC_M_CPU})
+  endif()
+
   # Set floating ABI
   if(CONFIG_FLOAT)
     if(CONFIG_FP_HARDABI)
@@ -35,5 +44,5 @@ function(nrfxlib_calculate_lib_path lib_path)
   if (NOT (SHORT_WCHAR_INDEX EQUAL -1))
     set(short_wchar "/short-wchar")
   endif()
-  set(${lib_path} "lib/${GCC_M_CPU}/${float_dir}${short_wchar}" PARENT_SCOPE)
+  set(${lib_path} "lib/${arch_soc_dir}/${float_dir}${short_wchar}" PARENT_SCOPE)
 endfunction()

--- a/nrf_802154_sl/CMakeLists.txt
+++ b/nrf_802154_sl/CMakeLists.txt
@@ -4,42 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-# Calculates relative path to the library to be uses taking into account
-# build type of the library, SoC type, floating point ABI, supported FEM type.
-# Note: Subdirectory layout is specific to nrf_802154_sl lib
-function(calculate_lib_path lib_path)
+nrfxlib_calculate_lib_path(lib_path SOC_MODE)
 
-  # Select SoC
-  if(CONFIG_SOC_NRF52840)
-    set(soc_dir "nrf52840_xxAA")
-  elseif(CONFIG_SOC_NRF52833)
-    set(soc_dir "nrf52833_xxAA")
-  elseif(CONFIG_SOC_NRF52820)
-    set(soc_dir "nrf52820_xxAA")
-  elseif(CONFIG_SOC_NRF52811)
-    set(soc_dir "nrf52811_xxAA")
-  else()
-    message(WARNING "Selected SoC is not supported by the nrf_802154_sl lib.")
-  endif()
-
-  # Select floating ABI
-  if(CONFIG_FLOAT)
-    if(CONFIG_FP_HARDABI)
-        set(float_dir hard)
-    elseif(CONFIG_FP_SOFTABI)
-        set(float_dir softfp)
-    else()
-        assert(0 "Unreachable code")
-    endif()
-  else()
-	  set(float_dir soft)
-  endif()
-
-  # Construct relative path to the selected lib
-  set(${lib_path} "lib/${soc_dir}/${float_dir}" PARENT_SCOPE)
-endfunction()
-
-calculate_lib_path(lib_path)
 set(NRF_802154_SL_LIB_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${lib_path})
 
 if(NOT EXISTS ${NRF_802154_SL_LIB_PATH})


### PR DESCRIPTION
This commit allows the nrfxlib_calculate_lib_path to use a SoC instead
of arch when finding the right path for the lib.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>